### PR TITLE
ci: use node lts version for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,8 @@ jobs:
       - name: "🔧 Setup"
         uses: actions/setup-node@v3
         with:
-          node-version: 18
-          cache: yarn
+          node-version: 'lts/*'
+          cache: 'yarn'
       - name: "📦 Install"
         run: yarn global add semantic-release @semantic-release/commit-analyzer @semantic-release/release-notes-generator @semantic-release/npm @semantic-release/github @semantic-release/git @semantic-release/changelog
       - name: "🔖 Release"


### PR DESCRIPTION
<!--
The title should summarise what the purpose of this change,

⚠️**NOTE:** The title must conform to the conventional commit message format outlined in CONTRIBUTING.md document, at the root of the project. This is to ensure the merge commit to the main branch is picked up by the CI and creates an entry in the CHANGELOG.md.
-->

# Description
<!-- Describe your changes in detail -->
* Replace Node version 18 with LTS for the release workflow

# Type of change
<!-- What type of change does this change introduce? Put an 'x' in all the boxes that apply. -->

- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🏗️ Build configuration (CI configuration, scaffolding etc.)
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 📝 Documentation update(s)
- [ ] 📦 Dependency update(s)
- [ ] 👩🏽‍💻 Improve developer experience
- [ ] ⚡ Improve performance
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] ♻ Refactor
- [ ] ⏪ Revert changes
- [ ] 🧪 New tests or updates to existing tests
